### PR TITLE
Fix compilation with recent rustc.

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,8 +1,7 @@
 [target.thumbv7em-none-eabihf]
 runner = 'arm-none-eabi-gdb'
 rustflags = [
-  "-C", "link-arg=-Wl,-Tlink.x",
-  "-C", "link-arg=-nostartfiles",
+  "-C", "link-arg=-Tlink.x",
 ]
 
 [build]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ path = "src/main.rs"
 [dependencies]
 alloc-cortex-m = "0.3.5"
 cast = { version = "0.2.2", default-features = false }
-cortex-m = "0.5.2"
+cortex-m = "0.5.8"
 cortex-m-rt = "0.5.1"
 cortex-m-semihosting = "0.3.0"
-panic-semihosting = "0.3.0"
-stm32h7 = { version = "0.2.0", features = ["stm32h7x3", "rt"] }
+panic-semihosting = "0.4.0"
+stm32h7 = { version = "0.8.0", features = ["stm32h743", "rt"] }
 embedded-hal = { version = "0.2.1", features = ["unproven"] }
 
 [profile.dev]

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -66,7 +66,7 @@ macro_rules! gpio {
         pub mod $gpiox {
             use core::marker::PhantomData;
             use embedded_hal::digital::{InputPin, OutputPin};
-            use stm32h7::stm32h7x3::{$GPIOX, RCC};
+            use stm32h7::stm32h743::{$GPIOX, RCC};
             use super::*;
 
             /// GPIO parts

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
 //! The main library interface
 #![deny(missing_docs)]
-#![feature(alloc)]
-#![feature(lang_items)]
 #![no_std]
 
 #[macro_use]
@@ -22,7 +20,7 @@ use cortex_m_rt::heap_start;
 use cortex_m_semihosting::hio;
 use embedded_hal::digital::OutputPin;
 use error::Error;
-use stm32h7::stm32h7x3::Peripherals;
+use stm32h7::stm32h743::Peripherals;
 
 mod error;
 mod gpio;

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ fn main() -> ! {
 #[lang = "oom"]
 #[no_mangle]
 // The out of memory handler
-pub fn rust_oom() -> ! {
+pub fn rust_oom(_: core::alloc::Layout) -> ! {
     loop {
         asm::bkpt();
     }


### PR DESCRIPTION
This wasn't building with rustc 1.37 for (at least) the following
reasons:

- Use of removed, previously-unstable features
- Linker args incompatible with new default linker (lld).

Updating the deps to versions that would build on current nightly
required some name changes etc.

This code *almost* builds on stable -- the remaining issues are an
ancient dependency relying on unstable versions of later-stabilized
features (linked-list-allocator), and the use of the OOM lang item in
main.